### PR TITLE
fix asyncio deprecation warnings.

### DIFF
--- a/async_serial_streams.py
+++ b/async_serial_streams.py
@@ -2,7 +2,7 @@ import asyncio
 import serial_asyncio
 
 
-async def main():
+async def main(loop):
     reader, _ = await serial_asyncio.open_serial_connection(url='./reader', baudrate=115200)
     print('Reader created')
     _, writer = await serial_asyncio.open_serial_connection(url='./writer', baudrate=115200)
@@ -10,7 +10,10 @@ async def main():
     messages = [b'foo\n', b'bar\n', b'baz\n', b'qux\n']
     sent = send(writer, messages)
     received = recv(reader)
-    await asyncio.wait([sent, received])
+    await asyncio.wait([
+        asyncio.create_task(sent),
+        asyncio.create_task(received)
+        ])
 
 
 async def send(w, msgs):
@@ -31,6 +34,7 @@ async def recv(r):
         print(f'received: {msg.rstrip().decode()}')
 
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
-loop.close()
+if __name__ == '__main__':
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(main(loop))
+    loop.close()


### PR DESCRIPTION
In `async_serial_streams.py` example, there were two deprecation warnings on Python 3.10.
* There is no current event loop
* The explicit passing of coroutine objects to `asyncio.wait()` is deprecated since Python 3.8 ...

```
(venv) $ python async_spike.py 
/path/to/async_spike.py:34: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
Reader created
Writer created
/path/to/async_spike.py:13: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
  await asyncio.wait([sent, received])
sent: foo
received: foo
sent: bar
```